### PR TITLE
add vlm baselines

### DIFF
--- a/baselines/open-set/README.md
+++ b/baselines/open-set/README.md
@@ -1,3 +1,0 @@
-# 🛠️ Open-set baselines (Under Construction)
-
-🚧 This repository is currently under active development.🚧

--- a/baselines/vlm_fusion/README.md
+++ b/baselines/vlm_fusion/README.md
@@ -1,0 +1,24 @@
+# Vision–language fusion baselines
+
+Reproduces **Table 7** from the FungiTastic paper: DistilBERT on Molmo captions, BEiT-Base/p16 image logits, and **mean-logit fusion**.
+
+## Pipeline
+
+1. **Captions** — Generate per-image JSON captions with [`metadata_extraction/captions/`](../../metadata_extraction/captions/) (Molmo-7B). Point `caption_dir` in `distilbert.ipynb` to a folder of `<filename>.json` files.
+2. **`distilbert.ipynb`** — Fine-tune DistilBERT on captions (10 epochs, cross-entropy); export **test** logits to `results/`.
+3. **`extract_logits.ipynb`** — Extract **test** logits from the fine-tuned BEiT checkpoint (`hf-hub:BVRA/beit_base_patch16_224.in1k_ft_fungitastic_224`).
+4. **`fusion.ipynb`** — Top-1, Top-3, and macro-F1 for BEiT, DistilBERT, and fusion (`logits_beit + logits_bert`) on FungiTastic-M and full.
+
+## Installation
+
+Python 3.10+.
+
+```bash
+pip install -r requirements.txt
+```
+
+## Paths
+
+Set `dataset_dir` to your FungiTastic root (default `/FungiTastic`). Metadata CSVs live under `dataset_dir/metadata/…`; test images under `dataset_dir/FungiTastic/…` or `FungiTastic-Mini/…`.
+
+DistilBERT checkpoints: `checkpoints/distilbert-ft-{mini,full}/`. BEiT logits: `features/beit-224-{mini,full}/`.

--- a/baselines/vlm_fusion/distilbert.ipynb
+++ b/baselines/vlm_fusion/distilbert.ipynb
@@ -1,0 +1,61 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# DistilBERT caption classifier\n\nFine-tune DistilBERT on Molmo captions for species classification (text-only baseline). Set `variant` to `\"mini\"` (FungiTastic-M) or `\"full\"` (FungiTastic)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\nimport torch\nfrom datasets import Dataset\nfrom transformers import (\n    AutoModelForSequenceClassification,\n    AutoTokenizer,\n    Trainer,\n    TrainingArguments,\n)\nimport evaluate\n\nfrom vlm_utils import load_captions, load_split_df\n\n# --- configuration ---\ndataset_dir = '/FungiTastic'\nvariant = 'mini'  # 'mini' | 'full'\ncaption_dir = f'{dataset_dir}/captions/{variant}'  # folder with <filename>.json\noutput_dir = f'checkpoints/distilbert-ft-{variant}'\nresults_dir = 'results'\n\ndf_train = load_split_df(dataset_dir, variant, 'train')\ndf_val = load_split_df(dataset_dir, variant, 'val')\ndf_test = load_split_df(dataset_dir, variant, 'test')\n\ncaptions_train = load_captions(caption_dir, df_train)\ncaptions_val = load_captions(caption_dir, df_val)\ncaptions_test = load_captions(caption_dir, df_test)\n\ntokenizer = AutoTokenizer.from_pretrained('distilbert-base-uncased')\n\ndef tokenize(batch):\n    return tokenizer(batch['text'], truncation=True, padding='max_length')\n\naccuracy = evaluate.load('accuracy')\n\ndef compute_metrics(eval_pred):\n    predictions, labels = eval_pred\n    predictions = np.argmax(predictions, axis=1)\n    return accuracy.compute(predictions=predictions, references=labels)\n\ndataset_train = Dataset.from_dict({'label': df_train['category_id'].values, 'text': captions_train}).map(tokenize, batched=True)\ndataset_val = Dataset.from_dict({'label': df_val['category_id'].values, 'text': captions_val}).map(tokenize, batched=True)\ndataset_test = Dataset.from_dict({'label': df_test['category_id'].values, 'text': captions_test}).map(tokenize, batched=True)\n\nnum_labels = int(df_train['category_id'].nunique())\nprint(f'{variant}: {len(df_train)} train, {len(df_val)} val, {len(df_test)} test, {num_labels} classes')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Train"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = AutoModelForSequenceClassification.from_pretrained(\n    'distilbert-base-uncased', num_labels=num_labels\n)\n\ntraining_args = TrainingArguments(\n    output_dir=output_dir,\n    eval_strategy='epoch',\n    learning_rate=5e-5,\n    per_device_train_batch_size=32,\n    per_device_eval_batch_size=32,\n    num_train_epochs=10,\n    weight_decay=0.01,\n    save_strategy='epoch',\n    load_best_model_at_end=True,\n)\n\ntrainer = Trainer(\n    model=model,\n    args=training_args,\n    train_dataset=dataset_train,\n    eval_dataset=dataset_val,\n    compute_metrics=compute_metrics,\n)\n\ntrainer.train()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export test logits\n\nSaves raw logits for `fusion.ipynb` (Table 7 evaluation on the test split)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n\nPath(results_dir).mkdir(parents=True, exist_ok=True)\n\ncheckpoints = sorted(Path(output_dir).glob('checkpoint-*'), key=lambda p: int(p.name.split('-')[-1]))\nassert checkpoints, f'No checkpoints in {output_dir}'\nbest_ckpt = str(checkpoints[-1])\nprint('Loading', best_ckpt)\n\nmodel = AutoModelForSequenceClassification.from_pretrained(best_ckpt)\ntrainer_eval = Trainer(model=model)\n\npreds = trainer_eval.predict(dataset_test)\npath = f'{results_dir}/bert_logits_{variant}_test.pth'\ntorch.save(torch.tensor(preds.predictions), path)\nprint('Saved', path)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/baselines/vlm_fusion/extract_logits.ipynb
+++ b/baselines/vlm_fusion/extract_logits.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# BEiT image logits for fusion\n\nExtract **test-set** logits from the fine-tuned BEiT-Base/p16 checkpoint. Run for `variant` = `\"mini\"` and `\"full\"`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\nimport cv2\nimport numpy as np\nimport torch\nimport timm\nimport torchvision.transforms as T\nfrom PIL import Image, ImageFile\nfrom tqdm import tqdm\n\nfrom vlm_utils import VARIANTS\n\nImageFile.LOAD_TRUNCATED_IMAGES = True\n\ndataset_dir = '/FungiTastic'\nvariant = 'mini'  # 'mini' | 'full'\ndevice = 'cuda'\nmodel_name = f'beit-224-{variant}'\nmodel_id = 'hf-hub:BVRA/beit_base_patch16_224.in1k_ft_fungitastic_224'\n\ncfg = VARIANTS[variant]\nsplit_name = f'{cfg[\"beit_prefix\"]}-test'\nimage_folder = os.path.join(dataset_dir, cfg['test_images'])\n\ntransforms = T.Compose([\n    T.Resize((224, 224)),\n    T.ToTensor(),\n    T.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),\n])\n\n\nclass ImageFolderDataset(torch.utils.data.Dataset):\n    def __init__(self, root, transforms, fallback=None):\n        self.files = sorted(os.listdir(root))\n        self.root = root\n        self.transforms = transforms\n        self.fallback = fallback\n\n    def __len__(self):\n        return len(self.files)\n\n    def __getitem__(self, idx):\n        name = self.files[idx]\n        path = os.path.join(self.root, name)\n        try:\n            img = Image.open(path).convert('RGB')\n        except (OSError, Image.UnidentifiedImageError):\n            img_cv = cv2.imread(path)\n            if img_cv is None:\n                if self.fallback is None:\n                    raise\n                return self.fallback.clone(), name\n            img = Image.fromarray(cv2.cvtColor(img_cv, cv2.COLOR_BGR2RGB))\n        return self.transforms(img), name\n\n\nmodel = timm.create_model(model_id, pretrained=True).to(device).eval()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.makedirs(f'features/{model_name}', exist_ok=True)\n\nif not os.path.isdir(image_folder):\n    raise FileNotFoundError(image_folder)\n\ndataset = ImageFolderDataset(image_folder, transforms, fallback=torch.randn(3, 224, 224))\nloader = torch.utils.data.DataLoader(dataset, batch_size=64, num_workers=6, shuffle=False)\n\nlogits_list, files_list = [], []\nfor imgs, files in tqdm(loader, desc=split_name):\n    with torch.no_grad():\n        logits_list.append(model(imgs.to(device)).cpu())\n        files_list.append(np.array(files))\n\nbundle = {\n    'files': np.concatenate(files_list),\n    'logits': torch.cat(logits_list),\n}\nout_path = f'features/{model_name}/{split_name}.pth'\ntorch.save(bundle, out_path)\nprint('Saved', out_path, bundle['logits'].shape)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/baselines/vlm_fusion/fusion.ipynb
+++ b/baselines/vlm_fusion/fusion.ipynb
@@ -1,0 +1,29 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Mean-logit fusion (Table 7)\n\nElement-wise sum of BEiT and DistilBERT test logits, then argmax. Reports metrics for FungiTastic-M and full."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n\nfrom vlm_utils import (\n    align_logits_by_filename,\n    classification_metrics,\n    load_split_df,\n    print_metrics_table,\n    VARIANTS,\n)\n\ndataset_dir = '/FungiTastic'\nresults_dir = 'results'\n\nfor variant in ('mini', 'full'):\n    df_test = load_split_df(dataset_dir, variant, 'test')\n    gt = torch.tensor(df_test['category_id'].values)\n    beit_prefix = VARIANTS[variant]['beit_prefix']\n\n    beit_bundle = torch.load(\n        f'features/beit-224-{variant}/{beit_prefix}-test.pth', weights_only=False\n    )\n    logits_beit = align_logits_by_filename(beit_bundle, df_test['filename'])\n    logits_bert = torch.load(f'{results_dir}/bert_logits_{variant}_test.pth', weights_only=True)\n    logits_fusion = logits_beit + logits_bert\n\n    rows = [\n        ('DistilBERT', classification_metrics(logits_bert, gt)),\n        ('BEiT-Base/p16', classification_metrics(logits_beit, gt)),\n        ('Fusion', classification_metrics(logits_fusion, gt)),\n    ]\n    title = 'FungiTastic-M' if variant == 'mini' else 'FungiTastic'\n    print(f'\\n=== {title} (test) ===')\n    print_metrics_table(rows)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/baselines/vlm_fusion/requirements.txt
+++ b/baselines/vlm_fusion/requirements.txt
@@ -1,0 +1,14 @@
+opencv-python~=4.10.0.84
+opencv-python-headless~=4.10.0.84
+pandas~=2.2.2
+torch~=2.3.1
+numpy~=1.26.4
+scikit-learn~=1.5.1
+tqdm~=4.66.4
+pillow~=10.4.0
+timm==1.0.7
+jupyterlab~=4.2.3
+transformers~=4.44.0
+datasets~=2.21.0
+evaluate~=0.4.2
+accelerate~=0.34.0

--- a/baselines/vlm_fusion/vlm_utils.py
+++ b/baselines/vlm_fusion/vlm_utils.py
@@ -1,0 +1,132 @@
+"""Shared helpers for vision–language fusion baselines."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+import torch
+from sklearn.metrics import f1_score
+
+# Filenames with missing or corrupt Molmo captions (train/val/test).
+INVALID_CAPTIONS = frozenset({
+    "1-3861325341.JPG",
+    "2-4100092812.JPG",
+    "0-2238480458.JPG",
+    "0-2238152962.JPG",
+    "1-2238552443.JPG",
+    "0-2597564674.JPG",
+    "1-2238554704.JPG",
+    "1-2238483885.JPG",
+    "1-2238523717.JPG",
+    "1-2237914372.JPG",
+    "0-2238496151.JPG",
+    "0-2238127565.JPG",
+    "0-2238365191.JPG",
+    "1-4169763613.JPG",
+    "0-4465865676.JPG",
+    "0-4465900600.JPG",
+})
+
+VARIANTS = {
+    "mini": {
+        "train_csv": "metadata/FungiTastic-Mini/FungiTastic-Mini-Train.csv",
+        "val_csv": "metadata/FungiTastic-Mini/FungiTastic-Mini-ClosedSet-Val.csv",
+        "test_csv": "metadata/FungiTastic-Mini/FungiTastic-Mini-ClosedSet-Test.csv",
+        "test_dev_csv": "metadata/FungiTastic/FungiTastic-test-DEV.csv",
+        "test_images": "FungiTastic-Mini/test/500p",
+        "beit_prefix": "mini-500p",
+    },
+    "full": {
+        "train_csv": "metadata/FungiTastic/FungiTastic-Train.csv",
+        "val_csv": "metadata/FungiTastic/FungiTastic-ClosedSet-Val.csv",
+        "test_csv": "metadata/FungiTastic/FungiTastic-ClosedSet-Test.csv",
+        "test_dev_csv": "metadata/FungiTastic/FungiTastic-test-DEV.csv",
+        "test_images": "FungiTastic/test/500p",
+        "beit_prefix": "full-500p",
+    },
+}
+
+
+def metadata_path(dataset_dir: str | Path, variant: str, split: str) -> Path:
+    cfg = VARIANTS[variant]
+    rel = {
+        "train": cfg["train_csv"],
+        "val": cfg["val_csv"],
+        "test": cfg["test_csv"],
+        "test_dev": cfg["test_dev_csv"],
+    }[split]
+    return Path(dataset_dir) / rel
+
+
+def load_split_df(dataset_dir: str | Path, variant: str, split: str) -> pd.DataFrame:
+    """Load a metadata CSV; for test, merge closed-set filenames with DEV labels."""
+    dataset_dir = Path(dataset_dir)
+    if split == "test":
+        df_test = pd.read_csv(metadata_path(dataset_dir, variant, "test"))
+        df_dev = pd.read_csv(metadata_path(dataset_dir, variant, "test_dev"))
+        df_dev = df_dev[df_dev["category_id"] != -1]
+        return pd.merge(
+            df_test,
+            df_dev[["filename", "category_id"]],
+            how="left",
+            on="filename",
+        )
+    return pd.read_csv(metadata_path(dataset_dir, variant, split))
+
+
+def read_caption(caption_dir: Path, filename: str) -> str:
+    if filename in INVALID_CAPTIONS:
+        return ""
+    path = caption_dir / f"{filename}.json"
+    with path.open() as f:
+        text = "".join(line.rstrip() for line in f)
+    return (
+        text.replace("\\n", "\n")
+        .replace("\n\n", " ")
+        .replace("\n", " ")
+        .replace('"', "")
+    )
+
+
+def load_captions(caption_dir: str | Path, df: pd.DataFrame) -> list[str]:
+    caption_dir = Path(caption_dir)
+    return [read_caption(caption_dir, row["filename"]) for _, row in df.iterrows()]
+
+
+def align_logits_by_filename(
+    feature_bundle: dict,
+    filenames: Iterable[str],
+) -> torch.Tensor:
+    """Reorder saved image logits to match a metadata CSV row order."""
+    files = np.asarray(feature_bundle["files"])
+    logits = feature_bundle["logits"]
+    rows = []
+    for name in filenames:
+        idx = int(np.where(files == name)[0][0])
+        rows.append(logits[idx])
+    return torch.stack(rows)
+
+
+def classification_metrics(logits: torch.Tensor, labels: torch.Tensor | np.ndarray) -> dict[str, float]:
+    if not isinstance(labels, torch.Tensor):
+        labels = torch.tensor(labels)
+    hits = labels == logits.argmax(1)
+    top1 = hits.float().mean().item() * 100
+
+    _, idx = logits.topk(3, dim=1)
+    top3_hits = [gt.item() in idx[i].tolist() for i, gt in enumerate(labels)]
+    top3 = float(np.mean(top3_hits)) * 100
+
+    f1_macro = f1_score(labels.numpy(), logits.argmax(1).numpy(), average="macro") * 100
+    return {"top1-acc": top1, "top3-acc": top3, "f1_macro": f1_macro}
+
+
+def print_metrics_table(rows: list[tuple[str, dict[str, float]]]) -> None:
+    header = f"{'Model':<22} {'Top1':>8} {'Top3':>8} {'F1_m':>8}"
+    print(header)
+    print("-" * len(header))
+    for name, m in rows:
+        print(f"{name:<22} {m['top1-acc']:8.1f} {m['top3-acc']:8.1f} {m['f1_macro']:8.1f}")


### PR DESCRIPTION
## Summary
- Adds `baselines/vlm_fusion/` for vision–language fusion (Table 7).
- DistilBERT training on captions, BEiT test logit extraction, mean-logit fusion.
- Shared helpers in `vlm_utils.py`; dependencies in `requirements.txt`.

## Notes
- Docs / site copy will follow in a separate PR to the docs branch.